### PR TITLE
add precise location from address

### DIFF
--- a/src/adjusters/TaxJar.php
+++ b/src/adjusters/TaxJar.php
@@ -168,6 +168,8 @@ class TaxJar extends Component implements AdjusterInterface
                 'to_country' => $this->_address->getCountry()->iso ?? '',
                 'to_zip' => $this->_address->zipCode ?? '',
                 'to_state' => $this->_address->getState()->abbreviation ?? '',
+                'to_city' => $this->_address->city ?? '',
+                'to_street' => $this->_address->address1 ?? '',
                 //'amount' => We pass line items so not needed
                 'shipping' => $this->_order->getTotalShippingCost(),
                 'line_items' => $lineItems


### PR DESCRIPTION


### Description
This adds the city and the street address to the tax lookup. There are certain postal codes that span multiple counties, and this helps alleviates the ambiguity from TaxJar's perspective, according to https://developers.taxjar.com/api/reference/#post-calculate-sales-tax-for-an-order


### Related issues
#12
