### PR TITLE
[2.x] Fix 400 error when cart has no line items

### DIFF
--- a/src/adjusters/TaxJar.php
+++ b/src/adjusters/TaxJar.php
@@ -78,6 +78,10 @@ class TaxJar extends Component implements AdjusterInterface
             return [];
         }
 
+        if (empty($order->getLineItems())) {
+            return [];
+        }
+
         try {
             $orderTaxes = $this->_getOrderTaxData();
         } catch (Exception $e) {


### PR DESCRIPTION
### Description

The adjuster calls the TaxJar API on every order recalculation regardless of whether the cart has any line items. When the cart is empty, TaxJar returns a `400 Bad Request – No amount or line items provided` error on every recalculation event. Added an early return in `adjust()` alongside the existing address guard.

### Related issues

Fixes #34 for Craft Commerce 4.x